### PR TITLE
feat: JIRA-13790 Add `GraphQLDescribable` concern

### DIFF
--- a/src/Definition/Concerns/GraphQLDescribable.php
+++ b/src/Definition/Concerns/GraphQLDescribable.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\GraphQLHelpers\Definition\Concerns;
+
+use Exception;
+use GraphQL\Type\Definition\Description;
+use Illuminate\Support\Str;
+use ReflectionEnum;
+use UnitEnum;
+
+/** @mixin UnitEnum */
+trait GraphQLDescribable
+{
+    public function description(): string
+    {
+        $reflection = new ReflectionEnum(static::class);
+        $constReflection = $reflection->getCase($this->name);
+
+        $descriptionAttributes = $constReflection->getAttributes(Description::class);
+
+        return match (count($descriptionAttributes)) {
+            0 => self::friendlyDescription($this->name),
+            1 => $descriptionAttributes[0]->newInstance()->description,
+            default => throw new Exception(
+                'You cannot use more than 1 description attribute on ' . class_basename(static::class) . '::' . $this->name
+            ),
+        };
+    }
+
+    private function friendlyDescription(string $name): string
+    {
+        if (ctype_upper(preg_replace('/[^a-zA-Z]/', '', $name))) {
+            $name = strtolower($name);
+        }
+
+        return ucfirst(str_replace('_', ' ', Str::snake($name)));
+    }
+}

--- a/tests/Unit/Definition/Concerns/GraphQLDescribable/GraphQLDescribableTest.php
+++ b/tests/Unit/Definition/Concerns/GraphQLDescribable/GraphQLDescribableTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\GraphQLHelpers\Tests\Unit\Definition\Concerns\GraphQLDescribable;
+
+use GraphQL\Type\Definition\Description;
+use Worksome\GraphQLHelpers\Definition\Concerns\GraphQLDescribable;
+
+#[Description('Dummy enum description')]
+enum DummyEnum
+{
+    use GraphQLDescribable;
+
+    #[Description('PascalCase description')]
+    case PascalCase;
+    #[Description('SCREAMING_SNAKE_CASE description')]
+    case SCREAMING_SNAKE_CASE; // phpcs:ignore
+    #[Description('snake_case description')]
+    case snake_case; // phpcs:ignore
+    case NoDescription;
+}
+
+it('can convert an enum to the correct case for GraphQL', function (DummyEnum $enum, string $description) {
+    expect($enum->description())->toBe($description);
+})->with([
+    [DummyEnum::PascalCase, 'PascalCase description'],
+    [DummyEnum::SCREAMING_SNAKE_CASE, 'SCREAMING_SNAKE_CASE description'],
+    [DummyEnum::snake_case, 'snake_case description'],
+    [DummyEnum::NoDescription, 'No description'],
+]);


### PR DESCRIPTION
This adds a new `GraphQLDescribable` trait, which allows for adding a `description()` method based on a `GraphQL\Type\Definition\Description` attribute, and falling back to a friendly name based on the key.