### PR TITLE
feat: add support for describing cases with closure

### DIFF
--- a/src/Definition/Attributes/CasesDescribedByClosure.php
+++ b/src/Definition/Attributes/CasesDescribedByClosure.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\GraphQLHelpers\Definition\Attributes;
+
+use Attribute;
+use Closure;
+use UnitEnum;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+readonly class CasesDescribedByClosure
+{
+    /** @param Closure(UnitEnum): string $describer */
+    public function __construct(public Closure $describer)
+    {
+    }
+}


### PR DESCRIPTION
> [!Warning]
> This would require PHP 8.5!

Example usage:

```php
#[CasesDescribedByClosure(Country::name(...))]
enum Country: string
{
    case AD = 'AD';
    // ...
}
```